### PR TITLE
Replace prebuilding step with clean installing

### DIFF
--- a/deploy-only.sh
+++ b/deploy-only.sh
@@ -45,17 +45,11 @@ remove_npm_token(){
 	fi
 }
 
-prebuild(){
-	step_start "Prebuilding"
-	prebuildscript=$(node -e "console.log(require('./package.json').scripts.prebuild || '')")
-	if [ "$prebuildscript" = '' ]
-	then
-		echo "No npm run prebuild script available"
-	else
-		add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
-		npm run prebuild || _exit $? "npm run prebuild failed"
-		remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
-	fi
+clean_install(){
+	step_start "Clean installing"
+	add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
+	npm ci || _exit $? "npm ci failed - Make sure your npm version is at least v5.7.0!"
+	remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
 }
 
 build(){
@@ -181,7 +175,7 @@ else
 	echo "Master has no tag yet, lets deploy (return value when getting tag: ${returnValueWhenGettingTag})"
 fi
 
-prebuild
+clean_install
 build
 deploy
 _exit 0

--- a/merge.sh
+++ b/merge.sh
@@ -10,17 +10,11 @@
 ################################################
 # Build
 ###############################################
-prebuild(){
-	step_start "Prebuilding"
-	prebuildscript=$(node -e "console.log(require('./package.json').scripts.prebuild || '')")
-	if [ "$prebuildscript" = '' ]
-	then
-		echo "No npm run prebuild script available"
-	else
-		add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
-		npm run prebuild || _exit $? "npm run prebuild failed"
-		remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
-	fi
+clean_install(){
+	step_start "Clean installing"
+	add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
+	npm ci || _exit $? "npm ci failed - Make sure your npm version is at least v5.7.0!"
+	remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
 }
 
 build(){
@@ -367,7 +361,7 @@ fi
 # Build
 ################################################
 
-prebuild
+clean_install
 build
 
 ################################################

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -8,17 +8,11 @@
 ################################################
 # Build
 ###############################################
-prebuild(){
-	step_start "Prebuilding"
-	prebuildscript=$(node -e "console.log(require('./package.json').scripts.prebuild || '')")
-	if [ "$prebuildscript" = '' ]
-	then
-		echo "No npm run prebuild script available"
-	else
-		add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
-		npm run prebuild || _exit $? "npm run prebuild failed"
-		remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
-	fi
+clean_install(){
+	step_start "Clean installing"
+	add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
+	npm ci || _exit $? "npm ci failed - Make sure your npm version is at least v5.7.0!"
+	remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
 }
 
 build (){
@@ -250,7 +244,7 @@ fi
 # Build
 ################################################
 
-prebuild
+clean_install
 build
 
 ################################################


### PR DESCRIPTION
To mimic the [new heroku nodejs build process](https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq), a `clean_install` step has been introduced, running before the `build` step in the deploy, merge, and PR scripts.

(Since `npm run build` automatically runs any `prebuild` scripts in package.json files, the former `prebuild` step was redundant)  