### PR TITLE
add-teamcity-install-script

### DIFF
--- a/merge.sh
+++ b/merge.sh
@@ -8,6 +8,22 @@
 # COMMIT_URL        - URL to the commit on GitHub. This script will add the commit SHA
 
 ################################################
+# Install dependencies
+###############################################
+teamcityinstall(){
+	step_start "Installing dependencies"
+	teamcityinstallscript=$(node -e "console.log(require('./package.json').scripts.teamcity-install || '')")
+	if [ "$teamcityinstallscript" = '' ]
+	then
+		echo "No npm teamcity-install script available"
+	else
+		add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
+		npm run teamcity-install || _exit $? "npm run teamcity-install failed"
+		remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
+	fi
+}
+
+################################################
 # Code formatting
 ###############################################
 format(){
@@ -400,6 +416,12 @@ then
 	step_start "Changing npm v${npmCurrent}->v${npmSpecified}"
 	sudo npm install -g "npm@${npmSpecified}" || build_done 1 "Could not install npm version ${npmSpecified}. Changing from current npm version ${npmCurrent}"
 fi
+
+################################################
+# Install dependencies
+################################################
+
+teamcityinstall
 
 ################################################
 # Build

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -6,6 +6,22 @@
 # BUILD_URL         - URL to the build on TeamCity, so we can link in slack messages
 
 ################################################
+# Install dependencies
+###############################################
+teamcityinstall(){
+	step_start "Installing dependencies"
+	teamcityinstallscript=$(node -e "console.log(require('./package.json').scripts.teamcity-install || '')")
+	if [ "$teamcityinstallscript" = '' ]
+	then
+		echo "No npm teamcity-install script available"
+	else
+		add_npm_token || _exit $? "Adding NPM_TOKEN env var to .npmrc failed"
+		npm run teamcity-install || _exit $? "npm run teamcity-install failed"
+		remove_npm_token || _exit $? "Removing NPM_TOKEN env var from .npmrc failed"
+	fi
+}
+
+################################################
 # Build
 ###############################################
 prebuild(){
@@ -280,6 +296,12 @@ then
 	step_start "Changing npm v${npmCurrent}->v${npmSpecified}"
 	sudo npm install -g "npm@${npmSpecified}" || build_done 1 "Could not install npm version ${npmSpecified}. Changing from current npm version ${npmCurrent}"
 fi
+
+################################################
+# Install dependencies
+################################################
+
+teamcityinstall
 
 ################################################
 # Build


### PR DESCRIPTION
**PROBLEM**:

Currently we are using the the `build` script in package.json to both install dependencies and build the client on teamcity. This means we need to declare a `heroku-postbuild` script that omits the install step and goes straight to building the client on Heroku to avoid installing the dependencies twice, because Heroku has already installed the dependencies for us.

If we do not have a client to build, we still have to declare a `build` script in package.json that only installs the dependencies because else the dependencies are not installed on teamcity. But this also means that Heroku installs the dependencies twice because Heroku automatically executes the `build` script. You can avoid that by declaring a `heroku-postbuild` script that does nothing, but this is also a strange solution.

**SOLUTION**:

This PR is about allowing you to declare a new `teamcity-install` script. This script is executed before the `build` script on teamcity and it is meant to only contain the command `npm ci`. 

For services with a client you can now define a `teamcity-install` script and `build` script. The `build` script will only build the client, and it can then be used by both teamcity and Heroku. No need to declare a `heroku-postbuild` script.

For service without a client you only need to declare a `teamcity-install` script. 